### PR TITLE
Extend ignition to handle associated topology

### DIFF
--- a/ignition/model/associated_topology.py
+++ b/ignition/model/associated_topology.py
@@ -11,7 +11,7 @@ class AssociatedTopology:
 
     def __validate_entry(self, entry):
         if not isinstance(entry, AssociatedTopologyEntry) and not isinstance(entry, RemovedTopologyEntry):
-            raise ValueError(f'Associated topology entry should an instance of {AssociatedTopologyEntry.__name__} or {RemovedTopologyEntry.__name__} but was {type(entry)}')
+            raise ValueError(f'Associated topology entry should be an instance of {AssociatedTopologyEntry.__name__} or {RemovedTopologyEntry.__name__} but was {type(entry)}')
 
     def add(self, name, entry):
         self.__validate_entry(entry)

--- a/ignition/service/templating.py
+++ b/ignition/service/templating.py
@@ -61,7 +61,7 @@ class ResourceTemplateContextCapability(Capability):
     """
 
     @interface
-    def build(self, system_properties, resource_properties, request_properties, deployment_location):
+    def build(self, system_properties, resource_properties, request_properties, deployment_location, associated_topology = None):
         """
         Builds a dictionary context, suitable for rendering templates, based on the properties of a request.
         The structure of the context depends on the chosen implementation
@@ -71,6 +71,7 @@ class ResourceTemplateContextCapability(Capability):
             resource_properties (dict or PropValueMap): dictionary of properties to include
             request_properties (dict or PropValueMap): dictionary of request properties to include
             deployment_location (dict): dictionary representing the deployment location details
+            associated_topology (dict): dictionary representing the infrastructure details
 
         Returns:
             the context (dict)
@@ -82,7 +83,7 @@ class ResourceTemplateContextService(Service, ResourceTemplateContextCapability)
     Implementation of the ResourceTemplateContextCapability which uses the ignition.templating.ResourceContextBuilder class 
     """
 
-    def build(self, system_properties, resource_properties, request_properties, deployment_location):
+    def build(self, system_properties, resource_properties, request_properties, deployment_location, associated_topology = None):
         """
         Builds a dictionary context, suitable for rendering templates, based on the properties of a request.
         Uses the ignition.templating.ResourceContextBuilder class, so consult it's documentation for details on the structure of the result.
@@ -101,16 +102,17 @@ class ResourceTemplateContextService(Service, ResourceTemplateContextCapability)
             resource_properties (dict or PropValueMap): dictionary of properties to include
             request_properties (dict or PropValueMap): dictionary of request properties to include
             deployment_location (dict): dictionary representing the deployment location details
+            associated_topology (dict): dictionary representing the infrastructure details
 
         Returns:
             the context (dict)
         """
-        builder = self._initiate_builder(system_properties, resource_properties, request_properties, deployment_location)
+        builder = self._initiate_builder(system_properties, resource_properties, request_properties, deployment_location, associated_topology)
         self._configure_additional_props(builder, system_properties, resource_properties, request_properties, deployment_location)
         return builder.result
 
-    def _initiate_builder(self, system_properties, resource_properties, request_properties, deployment_location):
-        return ResourceContextBuilder(system_properties, resource_properties, request_properties, deployment_location)
+    def _initiate_builder(self, system_properties, resource_properties, request_properties, deployment_location, associated_topology = None):
+        return ResourceContextBuilder(system_properties, resource_properties, request_properties, deployment_location, associated_topology)
     
     def _configure_additional_props(self, builder, system_properties, resource_properties, request_properties, deployment_location):
         #Room for extensions

--- a/ignition/service/templating.py
+++ b/ignition/service/templating.py
@@ -71,7 +71,7 @@ class ResourceTemplateContextCapability(Capability):
             resource_properties (dict or PropValueMap): dictionary of properties to include
             request_properties (dict or PropValueMap): dictionary of request properties to include
             deployment_location (dict): dictionary representing the deployment location details
-            associated_topology (dict): dictionary representing the infrastructure details
+            associated_topology (dict or AssociatedTopology): dictionary representing the associated topology details
 
         Returns:
             the context (dict)
@@ -102,7 +102,7 @@ class ResourceTemplateContextService(Service, ResourceTemplateContextCapability)
             resource_properties (dict or PropValueMap): dictionary of properties to include
             request_properties (dict or PropValueMap): dictionary of request properties to include
             deployment_location (dict): dictionary representing the deployment location details
-            associated_topology (dict): dictionary representing the infrastructure details
+            associated_topology (dict or AssociatedTopology): dictionary representing the associated topology details
 
         Returns:
             the context (dict)

--- a/ignition/templating/resource_context_builder.py
+++ b/ignition/templating/resource_context_builder.py
@@ -1,8 +1,10 @@
 from ignition.utils.propvaluemap import PropValueMap
+from ignition.model import associated_topology
 
 SYSTEM_PROPERTIES_KEY = 'system_properties'
 REQUEST_PROPERTIES_KEY = 'request_properties'
 DEPLOYMENT_LOCATION_KEY = 'deployment_location'
+ASSOCIATED_TOPOLOGY_KEY = 'associated_topology'
 
 class ResourceContextBuilder:
     """
@@ -18,6 +20,7 @@ class ResourceContextBuilder:
             system_properties: {'resourceId': '123', 'resourceName': 'example'}
             deployment_location = {'name': 'example-location', 'type': 'test', 'properties': {'dlPropA': 'location property'}}
             request_properties: {'requestA': 'request valueA'}
+            associated_topology: {'infrastructureNameA': {'infrastructureId': 'a58b884d-1209-49e0-8966-13fcad548f4a', 'infrastructureType': 'Openstack'}}
         Result:
         {
             'propertyA' : 'valueA',
@@ -34,6 +37,12 @@ class ResourceContextBuilder:
             },
             'request_properties': {
                 'requestA': 'request_valueA'
+            },
+            associated_topology: {
+                'infrastructureNameA': {
+                    'infrastructureId': 'a58b884d-1209-49e0-8966-13fcad548f4a',
+                    'infrastructureType': 'Openstack'
+                }
             }
         }
 
@@ -41,7 +50,7 @@ class ResourceContextBuilder:
         result (dict): the context built with this instance
     """
 
-    def __init__(self, system_properties, resource_properties, request_properties, deployment_location):
+    def __init__(self, system_properties, resource_properties, request_properties, deployment_location, associated_topology = None):
         """
         Initiate a builder
 
@@ -50,22 +59,25 @@ class ResourceContextBuilder:
             resource_properties (dict or PropValueMap): dictionary of resource properties to include
             request_properties (dict or PropValueMap): dictionary of request properties to include
             deployment_location (dict): dictionary representing the deployment location details
+            associated_topology (dict): dictionary representing the infrastructure details
         """
         self.result = {
             SYSTEM_PROPERTIES_KEY: {},
             REQUEST_PROPERTIES_KEY: {},
-            DEPLOYMENT_LOCATION_KEY: {}
+            DEPLOYMENT_LOCATION_KEY: {},
+            ASSOCIATED_TOPOLOGY_KEY: {}
         }
         self.add_system_properties(system_properties)
         self.add_resource_properties(resource_properties)
         self.add_request_properties(request_properties)
         self.set_deployment_location(deployment_location)
+        self.set_associated_topology(associated_topology)
 
     def __reserved_key_error_msg(self, reserved_key):
         return f'property with name \'{reserved_key}\' cannot be used as this is a reserved word'
 
     def __check_for_reserved_key(self, key):
-        if key in [SYSTEM_PROPERTIES_KEY, DEPLOYMENT_LOCATION_KEY, REQUEST_PROPERTIES_KEY]:
+        if key in [SYSTEM_PROPERTIES_KEY, DEPLOYMENT_LOCATION_KEY, REQUEST_PROPERTIES_KEY, ASSOCIATED_TOPOLOGY_KEY]:
             raise ValueError(self.__reserved_key_error_msg(key))
 
     def add_resource_properties(self, resource_properties):
@@ -204,6 +216,20 @@ class ResourceContextBuilder:
             this builder
         """
         self.result[DEPLOYMENT_LOCATION_KEY] = deployment_location
+        return self
+    
+    def set_associated_topology(self, associated_topology):
+        """
+        Change the value of the associated topology
+
+        Args:
+            associated topology (dict): dictionary representing the associated topology details
+
+        Returns:
+            this builder
+        """
+        if associated_topology is not None:
+            self.result[ASSOCIATED_TOPOLOGY_KEY] = associated_topology.to_dict()
         return self
 
     def add_deployment_location_property(self, key, value):

--- a/tests/unit/model/test_associated_topology.py
+++ b/tests/unit/model/test_associated_topology.py
@@ -86,7 +86,7 @@ class TestAssociatedTopology(unittest.TestCase):
         topology = AssociatedTopology()
         with self.assertRaises(ValueError) as context:
             topology.add('A', 'not_an_entry')
-        self.assertEqual(str(context.exception), 'Associated topology entry should an instance of AssociatedTopologyEntry or RemovedTopologyEntry but was <class \'str\'>')
+        self.assertEqual(str(context.exception), 'Associated topology entry should be an instance of AssociatedTopologyEntry or RemovedTopologyEntry but was <class \'str\'>')
 
     def test_add_entry(self):
         topology = AssociatedTopology()

--- a/tests/unit/service/test_templating.py
+++ b/tests/unit/service/test_templating.py
@@ -58,7 +58,8 @@ class TestResourceTemplateContextService(unittest.TestCase):
                 'properties': {
                     'dlPropA': 'A DL Prop'
                 }
-            }
+            },
+            'associated_topology': {}
         })
 
     def test_extension(self):
@@ -100,5 +101,6 @@ class TestResourceTemplateContextService(unittest.TestCase):
                     'dlPropA': 'A DL Prop',
                     'ExtDlPropA': 'A DL Prop'
                 }
-            }
+            },
+            'associated_topology': {}
         })

--- a/tests/unit/templating/test_resource_context_builder.py
+++ b/tests/unit/templating/test_resource_context_builder.py
@@ -42,7 +42,8 @@ class TestResourceContextBuilder(unittest.TestCase):
                 'properties': {
                     'dlPropA': 'A DL Prop'
                 }
-            }
+            },
+            'associated_topology': {}
         })
 
     def test_init_with_prop_value_maps(self):
@@ -65,7 +66,8 @@ class TestResourceContextBuilder(unittest.TestCase):
                 'properties': {
                     'dlPropA': 'A DL Prop'
                 }
-            }
+            },
+            'associated_topology': {}
         })
 
     def test_add_resource_properties(self):
@@ -89,7 +91,8 @@ class TestResourceContextBuilder(unittest.TestCase):
                 'properties': {
                     'dlPropA': 'A DL Prop'
                 }
-            }
+            },
+            'associated_topology': {}
         })
 
     def test_add_resource_properties_from_prop_value_map(self):
@@ -113,7 +116,8 @@ class TestResourceContextBuilder(unittest.TestCase):
                 'properties': {
                     'dlPropA': 'A DL Prop'
                 }
-            }
+            },
+            'associated_topology': {}
         })
 
     
@@ -137,7 +141,8 @@ class TestResourceContextBuilder(unittest.TestCase):
                 'properties': {
                     'dlPropA': 'A DL Prop'
                 }
-            }
+            },
+            'associated_topology': {}
         })
 
     def test_add_system_properties(self):
@@ -161,7 +166,8 @@ class TestResourceContextBuilder(unittest.TestCase):
                 'properties': {
                     'dlPropA': 'A DL Prop'
                 }
-            }
+            },
+            'associated_topology': {}
         })
 
     def test_add_system_properties_from_prop_value_map(self):
@@ -185,7 +191,8 @@ class TestResourceContextBuilder(unittest.TestCase):
                 'properties': {
                     'dlPropA': 'A DL Prop'
                 }
-            }
+            },
+            'associated_topology': {}
         })
 
     def test_add_system_property(self):
@@ -208,7 +215,8 @@ class TestResourceContextBuilder(unittest.TestCase):
                 'properties': {
                     'dlPropA': 'A DL Prop'
                 }
-            }
+            },
+            'associated_topology': {}
         })
 
     def test_add_resource_properties_with_reserved_system_property_keyword(self):
@@ -265,7 +273,8 @@ class TestResourceContextBuilder(unittest.TestCase):
                 'keyName': 'theName',
                 'publicKey': 'thePublicPart',
                 'privateKey': 'ssshhh'
-            }
+            },
+            'associated_topology': {}
         })
 
     def test_add_key_system_property(self):
@@ -281,7 +290,8 @@ class TestResourceContextBuilder(unittest.TestCase):
                     'publicKey': 'thePublicPart',
                     'privateKey': 'ssshhh'
                 }
-            }
+            },
+            'associated_topology': {}
         })
 
     def test_add_key_request_property(self):
@@ -297,7 +307,8 @@ class TestResourceContextBuilder(unittest.TestCase):
                     'publicKey': 'thePublicPart',
                     'privateKey': 'ssshhh'
                 }
-            }
+            },
+            'associated_topology': {}
         })
 
     def test_set_deployment_location(self):
@@ -326,7 +337,8 @@ class TestResourceContextBuilder(unittest.TestCase):
                 'properties': {
                     'dlPropA': 'Alternative DL Prop'
                 }
-            }
+            },
+            'associated_topology': {}
         })
 
     def test_add_deployment_location_property(self):
@@ -349,7 +361,8 @@ class TestResourceContextBuilder(unittest.TestCase):
                     'dlPropA': 'A DL Prop',
                     'dlPropB': 'B DL Prop'
                 }
-            }
+            },
+            'associated_topology': {}
         })
 
     def test_deployment_location_property_not_hidden(self):
@@ -372,5 +385,6 @@ class TestResourceContextBuilder(unittest.TestCase):
                 'properties': {
                     'dlPropA': 'A DL Prop'
                 }
-            }
+            },
+            'associated_topology': {}
         })


### PR DESCRIPTION
- **Description of the changes**: Extended ignition to handle associated topology. Adjusted unit tests. Run uni tests for ignition, kuberneted-driver, oenstack-vim-driver, ansible-lifecycle-driver. #93 

- **Signed-off-by**: _**Elisabetta Flamini* **\<elisafla@uk.ibm.com>**_