### PR TITLE
issues/97: refactor construction of KafkaAdminClient, KafkaProducer a…

### DIFF
--- a/ignition/boot/configurators/jobqueue.py
+++ b/ignition/boot/configurators/jobqueue.py
@@ -33,7 +33,7 @@ class JobQueueConfigurator():
                 # Replace spaces with underscore
                 safe_topic_name = safe_topic_name.replace(' ', '_')
                 messaging_config.topics.job_queue.name = '{0}_job_queue'.format(safe_topic_name)
-            TopicCreator().create_topic_if_needed(messaging_config.connection_address, messaging_config.topics.job_queue)
+            TopicCreator().create_topic_if_needed(messaging_config, messaging_config.topics.job_queue)
             service_register.add_service(ServiceRegistration(MessagingJobQueueService, job_queue_config=JobQueueProperties, postal_service=PostalCapability, inbox_service=InboxCapability, topics_config=TopicsProperties, messaging_config=MessagingProperties))
         else:
             logger.debug('Disabled: bootstrapped Job Queue Service')

--- a/ignition/boot/configurators/messaging.py
+++ b/ignition/boot/configurators/messaging.py
@@ -34,7 +34,7 @@ class MessagingConfigurator():
             if messaging_config.connection_address is None:
                 raise ValueError('messaging.connection_address must be set when bootstrap.messaging.delivery_enabled is True')
             validate_no_service_with_capability_exists(service_register, DeliveryCapability, 'Delivery Service', 'bootstrap.messaging.delivery_enabled')
-            service_register.add_service(ServiceRegistration(KafkaDeliveryService, messaging_config=MessagingProperties))
+            service_register.add_service(ServiceRegistration(KafkaDeliveryService, messaging_properties=MessagingProperties))
         else:
             logger.debug('Disabled: bootstrapped Messaging Delivery Service')
 
@@ -46,6 +46,6 @@ class MessagingConfigurator():
             if messaging_config.connection_address is None:
                 raise ValueError('messaging.connection_address must be set when bootstrap.messaging.inbox_enabled is True')
             validate_no_service_with_capability_exists(service_register, InboxCapability, 'Inbox Service', 'bootstrap.messaging.inbox_enabled')
-            service_register.add_service(ServiceRegistration(KafkaInboxService, messaging_config=MessagingProperties))
+            service_register.add_service(ServiceRegistration(KafkaInboxService, messaging_properties=MessagingProperties))
         else:
             logger.debug('Disabled: bootstrapped Messaging Inbox Service')

--- a/ignition/boot/configurators/requestqueue.py
+++ b/ignition/boot/configurators/requestqueue.py
@@ -30,8 +30,8 @@ class RequestQueueConfigurator():
 
             if auto_config.resource_driver.api_enabled is True:
                 validate_no_service_with_capability_exists(service_register, LifecycleRequestQueueCapability, 'Lifecycle Request Queue', 'bootstrap.request_queue.enabled')
-                service_register.add_service(ServiceRegistration(KafkaLifecycleConsumerFactory, resource_driver_config.lifecycle_request_queue, messaging_config=MessagingProperties))
-                service_register.add_service(ServiceRegistration(KafkaLifecycleRequestQueueService, lifecycle_messaging_service=LifecycleMessagingCapability, messaging_config=MessagingProperties, resource_driver_config=ResourceDriverProperties,
+                service_register.add_service(ServiceRegistration(KafkaLifecycleConsumerFactory, resource_driver_config.lifecycle_request_queue, messaging_properties=MessagingProperties))
+                service_register.add_service(ServiceRegistration(KafkaLifecycleRequestQueueService, lifecycle_messaging_service=LifecycleMessagingCapability, messaging_properties=MessagingProperties, resource_driver_config=ResourceDriverProperties,
                     postal_service=PostalCapability, driver_files_manager=DriverFilesManagerCapability, lifecycle_consumer_factory=LifecycleConsumerFactoryCapability))
         else:
             logger.debug('Disabled: bootstrapped Request Queue Service')
@@ -48,5 +48,5 @@ class RequestQueueConfigurator():
             lifecycle_request_queue_config.topic.name = LIFECYCLE_REQUEST_QUEUE_TOPIC.format(safe_topic_name)
             lifecycle_request_queue_config.failed_topic.name = FAILED_REQUEST_QUEUE.format(lifecycle_request_queue_config.topic.name)
 
-        self.topic_creator.create_topic_if_needed(messaging_config.connection_address, lifecycle_request_queue_config.topic)
-        self.topic_creator.create_topic_if_needed(messaging_config.connection_address, lifecycle_request_queue_config.failed_topic)
+        self.topic_creator.create_topic_if_needed(messaging_config, lifecycle_request_queue_config.topic)
+        self.topic_creator.create_topic_if_needed(messaging_config, lifecycle_request_queue_config.failed_topic)

--- a/ignition/boot/configurators/resourcedriverapi.py
+++ b/ignition/boot/configurators/resourcedriverapi.py
@@ -116,7 +116,7 @@ class ResourceDriverServicesConfigurator():
                 raise ValueError('messaging.connection_address must be set when bootstrap.resource_driver.lifecycle_messaging_service_enabled')
             if messaging_config.topics.lifecycle_execution_events is None:
                 raise ValueError('messaging.topics.lifecycle_execution_events must be set when bootstrap.resource_driver.lifecycle_messaging_service_enabled')
-            TopicCreator().create_topic_if_needed(messaging_config.connection_address, messaging_config.topics.lifecycle_execution_events)
+            TopicCreator().create_topic_if_needed(messaging_config, messaging_config.topics.lifecycle_execution_events)
             service_register.add_service(ServiceRegistration(LifecycleMessagingService, postal_service=PostalCapability, topics_configuration=TopicsProperties))
         else:
             logger.debug('Disabled: bootstrapped Resource Driver Lifecycle Messaging Service')

--- a/tests/unit/boot/configurators/test_jobqueue.py
+++ b/tests/unit/boot/configurators/test_jobqueue.py
@@ -6,6 +6,7 @@ from ignition.service.queue import JobQueueCapability, MessagingJobQueueService,
 from ignition.service.messaging import MessagingProperties, TopicsProperties, PostalCapability, InboxCapability
 from ignition.service.framework import ServiceRegistration
 
+
 class TestJobQueueConfigurator(ConfiguratorTestCase):
 
     def __bootstrap_config(self):
@@ -78,5 +79,7 @@ class TestJobQueueConfigurator(ConfiguratorTestCase):
         self.mock_service_register.get_service_offering_capability.return_value = None
         JobQueueConfigurator().configure(configuration, self.mock_service_register)
         mock_topic_creator_init.assert_called_once()
-        mock_topic_creator_init.return_value.create_topic_if_needed.assert_called_once_with('testaddr', configuration.property_groups.get_property_group(MessagingProperties).topics.job_queue)
+        messaging_properties = MessagingProperties()
+        messaging_properties.connection_address = 'testaddr'
+        mock_topic_creator_init.return_value.create_topic_if_needed.assert_called_once_with(messaging_properties, configuration.property_groups.get_property_group(MessagingProperties).topics.job_queue)
 

--- a/tests/unit/boot/configurators/test_messaging.py
+++ b/tests/unit/boot/configurators/test_messaging.py
@@ -47,7 +47,7 @@ class TestMessagingConfigurator(ConfiguratorTestCase):
         self.mock_service_register.get_service_offering_capability.return_value = None
         MessagingConfigurator().configure(configuration, self.mock_service_register)
         registered_service = self.assert_single_service_registered()
-        self.assert_service_registration_equal(registered_service, ServiceRegistration(KafkaDeliveryService, messaging_config=MessagingProperties))
+        self.assert_service_registration_equal(registered_service, ServiceRegistration(KafkaDeliveryService, messaging_properties=MessagingProperties))
 
     def test_configure_delivery_fails_when_already_registered(self):
         configuration = self.__bootstrap_config()
@@ -74,7 +74,7 @@ class TestMessagingConfigurator(ConfiguratorTestCase):
         self.mock_service_register.get_service_offering_capability.return_value = None
         MessagingConfigurator().configure(configuration, self.mock_service_register)
         registered_service = self.assert_single_service_registered()
-        self.assert_service_registration_equal(registered_service, ServiceRegistration(KafkaInboxService, messaging_config=MessagingProperties))
+        self.assert_service_registration_equal(registered_service, ServiceRegistration(KafkaInboxService, messaging_properties=MessagingProperties))
 
     def test_configure_inbox_fails_when_already_registered(self):
         configuration = self.__bootstrap_config()

--- a/tests/unit/boot/configurators/test_requestqueue.py
+++ b/tests/unit/boot/configurators/test_requestqueue.py
@@ -53,7 +53,7 @@ class TestRequestQueueConfigurator(ConfiguratorTestCase):
         RequestQueueConfigurator(self.mock_topic_creator).configure(configuration, self.mock_service_register)
         registered_service = self.assert_services_registered(2)
 
-        self.assert_service_registration_equal(registered_service[1], ServiceRegistration(KafkaLifecycleRequestQueueService, lifecycle_messaging_service=LifecycleMessagingCapability, messaging_config=MessagingProperties,
+        self.assert_service_registration_equal(registered_service[1], ServiceRegistration(KafkaLifecycleRequestQueueService, lifecycle_messaging_service=LifecycleMessagingCapability, messaging_properties=MessagingProperties,
                 resource_driver_config=ResourceDriverProperties, postal_service=PostalCapability, driver_files_manager=DriverFilesManagerCapability,
                 lifecycle_consumer_factory=LifecycleConsumerFactoryCapability))
 
@@ -64,16 +64,22 @@ class TestRequestQueueConfigurator(ConfiguratorTestCase):
         service_call = service_calls[0]
         service_call_args, kwargs = service_call
         self.assertEqual(len(service_call_args), 2)
-        connection_address = service_call_args[0]
-        self.assertEqual(connection_address, "kafka")
+        messaging_properties = service_call_args[0]
+        self.assertEqual(messaging_properties.connection_address, "kafka")
+        self.assertEqual(messaging_properties.config, {
+            'api_version_auto_timeout_ms': 5000,
+        })
         topic_config_properties = service_call_args[1]
         self.assertIsInstance(topic_config_properties, TopicConfigProperties)
 
         service_call = service_calls[1]
         service_call_args, kwargs = service_call
         self.assertEqual(len(service_call_args), 2)
-        connection_address = service_call_args[0]
-        self.assertEqual(connection_address, "kafka")
+        messaging_properties = service_call_args[0]
+        self.assertEqual(messaging_properties.connection_address, "kafka")
+        self.assertEqual(messaging_properties.config, {
+            'api_version_auto_timeout_ms': 5000,
+        })
         topic_config_properties = service_call_args[1]
         self.assertIsInstance(topic_config_properties, TopicConfigProperties)
 

--- a/tests/unit/service/test_messaging.py
+++ b/tests/unit/service/test_messaging.py
@@ -1,7 +1,9 @@
 import unittest
 import time
+import copy
 from unittest.mock import patch, MagicMock, call
-from ignition.service.messaging import PostalService, KafkaDeliveryService, KafkaInboxService, Envelope, Message
+from ignition.service.messaging import PostalService, KafkaDeliveryService, KafkaInboxService, Envelope, Message, MessagingProperties
+from kafka import KafkaProducer
 
 
 class TestPostalService(unittest.TestCase):
@@ -30,32 +32,37 @@ class TestPostalService(unittest.TestCase):
 class TestKafkaDeliveryService(unittest.TestCase):
 
     def setUp(self):
-        self.mock_messaging_config = MagicMock(connection_address='test:9092', api_version_auto_timeout_ms=5000)
+        self.messaging_properties = MessagingProperties()
+        self.messaging_properties.connection_address='test:9092'
+        self.messaging_properties.config={'api_version_auto_timeout_ms': 5000}
 
     def test_init_without_messaging_config_throws_error(self):
         with self.assertRaises(ValueError) as context:
             KafkaDeliveryService()
-        self.assertEqual(str(context.exception), 'messaging_config argument not provided')
+        self.assertEqual(str(context.exception), 'messaging_properties argument not provided')
 
     def test_init_without_bootstrap_servers_throws_error(self):
-        mock_messaging_config = MagicMock(connection_address=None)
+        messaging_properties = MessagingProperties()
+        messaging_properties.connection_address=None
         with self.assertRaises(ValueError) as context:
-            KafkaDeliveryService(messaging_config=mock_messaging_config)
-        self.assertEqual(str(context.exception), 'connection_address not set on messaging_config')
+            KafkaDeliveryService(messaging_properties=messaging_properties)
+        self.assertEqual(str(context.exception), 'connection_address not set on messaging_properties')
 
     @patch('ignition.service.messaging.KafkaProducer')
     def test_deliver(self, mock_kafka_producer_init):
-        delivery_service = KafkaDeliveryService(messaging_config=self.mock_messaging_config)
+        # need to set this explicitly because we've patched KafkaProducer
+        mock_kafka_producer_init.DEFAULT_CONFIG = KafkaProducer.DEFAULT_CONFIG
+        delivery_service = KafkaDeliveryService(messaging_properties=self.messaging_properties)
         test_envelope = Envelope('test_topic', Message('test message'))
         delivery_service.deliver(test_envelope)
-        mock_kafka_producer_init.assert_called_once_with(bootstrap_servers='test:9092', api_version_auto_timeout_ms=5000)
+        mock_kafka_producer_init.assert_called_once_with(bootstrap_servers='test:9092', api_version_auto_timeout_ms=5000, client_id='ignition')
         self.assertEqual(delivery_service.producer, mock_kafka_producer_init.return_value)
         mock_kafka_producer = mock_kafka_producer_init.return_value
         mock_kafka_producer.send.assert_called_once_with('test_topic', b'test message')
 
     @patch('ignition.service.messaging.KafkaProducer')
     def test_deliver_throws_error_when_envelope_is_none(self, mock_kafka_producer_init):
-        delivery_service = KafkaDeliveryService(messaging_config=self.mock_messaging_config)
+        delivery_service = KafkaDeliveryService(messaging_properties=self.messaging_properties)
         with self.assertRaises(ValueError) as context:
             delivery_service.deliver(None)
         self.assertEqual(str(context.exception), 'An envelope must be passed to deliver a message')
@@ -64,30 +71,33 @@ class TestKafkaDeliveryService(unittest.TestCase):
 class TestKafkaInboxService(unittest.TestCase):
 
     def setUp(self):
-        self.mock_messaging_config = MagicMock(connection_address='test:9092', api_version_auto_timeout_ms=5000)
+        self.messaging_properties = MessagingProperties()
+        self.messaging_properties.connection_address='test:9092'
+        self.messaging_properties.config={'api_version_auto_timeout_ms':5000}
 
     def test_init_without_messaging_config_throws_error(self):
         with self.assertRaises(ValueError) as context:
             KafkaInboxService()
-        self.assertEqual(str(context.exception), 'messaging_config argument not provided')
+        self.assertEqual(str(context.exception), 'messaging_properties argument not provided')
 
     def test_init_without_bootstrap_servers_throws_error(self):
-        mock_messaging_config = MagicMock(connection_address=None)
+        messaging_properties = MessagingProperties()
+        messaging_properties.connection_address=None
         with self.assertRaises(ValueError) as context:
-            KafkaInboxService(messaging_config=mock_messaging_config)
-        self.assertEqual(str(context.exception), 'connection_address not set on messaging_config')
+            KafkaInboxService(messaging_properties=messaging_properties)
+        self.assertEqual(str(context.exception), 'connection_address not set on messaging_properties')
 
     @patch('ignition.service.messaging.KafkaInboxThread')
     def test_watch_inbox_starts_thread(self, mock_kafka_inbox_thread_init):
-        inbox_service = KafkaInboxService(messaging_config=self.mock_messaging_config)
+        inbox_service = KafkaInboxService(messaging_properties=self.messaging_properties)
         mock_read_inbox_func = MagicMock()
         inbox_service.watch_inbox('test_group', 'test_topic', mock_read_inbox_func)
-        mock_kafka_inbox_thread_init.assert_called_once_with('test:9092', 5000, 'test_group', 'test_topic', mock_read_inbox_func, inbox_service._KafkaInboxService__thread_exit_func)
+        mock_kafka_inbox_thread_init.assert_called_once_with('test:9092', 'test_group', 'test_topic', mock_read_inbox_func, inbox_service._KafkaInboxService__thread_exit_func, self.messaging_properties.config)
         mock_kafka_inbox_thread_init.return_value.start.assert_called_once()
 
     @patch('ignition.service.messaging.KafkaConsumer')
     def test_watch_inbox_thread_inits_consumer(self, mock_kafka_consumer_init):
-        inbox_service = KafkaInboxService(messaging_config=self.mock_messaging_config)
+        inbox_service = KafkaInboxService(messaging_properties=self.messaging_properties)
         mock_read_inbox_func = MagicMock()
         inbox_service.watch_inbox('test_group', 'test_topic', mock_read_inbox_func)
         mock_kafka_consumer_init.assert_called_once_with('test_topic', bootstrap_servers='test:9092', group_id='test_group', enable_auto_commit=False)
@@ -114,13 +124,20 @@ class TestKafkaInboxService(unittest.TestCase):
                 infinite_iter_has_stopped = True
             return iter
         mock_kafka_consumer.__iter__.side_effect = build_iter()
-        inbox_service = KafkaInboxService(messaging_config=self.mock_messaging_config)
+        inbox_service = KafkaInboxService(messaging_properties=self.messaging_properties)
         mock_read_inbox_func = MagicMock()
         inbox_service.watch_inbox('test_group', 'test_topic', mock_read_inbox_func)
         time.sleep(0.01)
         try:
             self.assertEqual(len(inbox_service.active_threads), 1)
-            mock_kafka_consumer_init.assert_called_once_with('test_topic', bootstrap_servers='test:9092', api_version_auto_timeout_ms=5000, group_id='test_group', enable_auto_commit=False)
+            expected_config = copy.copy(self.messaging_properties.config)
+            expected_config = {
+                'bootstrap_servers': 'test:9092',
+                'group_id': 'test_group',
+                'enable_auto_commit': False,
+                'client_id': 'ignition'
+            }
+            mock_kafka_consumer_init.assert_called_once_with('test_topic', **expected_config)
             mock_kafka_consumer.__iter__.assert_called_once()
             mock_record_1.value.decode.assert_called_once_with('utf-8')
             mock_record_2.value.decode.assert_not_called()
@@ -152,7 +169,7 @@ class TestKafkaInboxService(unittest.TestCase):
                         break
             return iter
         mock_kafka_consumer.__iter__.side_effect = build_iter()
-        inbox_service = KafkaInboxService(test_mode=True, messaging_config=self.mock_messaging_config)
+        inbox_service = KafkaInboxService(test_mode=True, messaging_properties=self.messaging_properties)
         mock_read_inbox_func = MagicMock()
         mock_read_inbox_func.side_effect = ValueError('Test error')
         self.assertFalse(inbox_service.exited)

--- a/tests/unit/service/test_requestqueue.py
+++ b/tests/unit/service/test_requestqueue.py
@@ -17,7 +17,6 @@ class TestRequestQueueService(unittest.TestCase):
         self.mock_postal_service = MagicMock()
         self.mock_lifecycle_messaging_service = MagicMock()
         self.mock_driver_files_manager = MagicMock()
-        self.mock_messaging_config = MagicMock(connection_address='test:9092')
 
     def test_kafka_request_queue_handler_null_request_id(self):
         mock_messaging_service = MagicMock()


### PR DESCRIPTION
…nd KafkaConsumer instances to allow configuration to be overridden from config file

Note: tested in drivers Openstack, Ansible, Kubernetes