### PR TITLE
Update messaging.py

### DIFF
--- a/ignition/service/messaging.py
+++ b/ignition/service/messaging.py
@@ -7,7 +7,7 @@ from ignition.service.config import ConfigurationPropertiesGroup, ConfigurationP
 from kafka import KafkaProducer, KafkaConsumer
 from kafka.admin import KafkaAdminClient, NewTopic
 from kafka.errors import BrokerResponseError, TopicAlreadyExistsError
-from signal import signal, getsignal, SIGINT, SIGTERM, SIGQUIT, SIGCHLD, SIG_IGN, SIG_DFL
+from signal import signal, SIGTERM
 
 logger = logging.getLogger(__name__)
 
@@ -201,7 +201,7 @@ class KafkaDeliveryService(Service, DeliveryCapability):
     def __init__(self, **kwargs):
         if 'messaging_properties' not in kwargs:
             raise ValueError('messaging_properties argument not provided')
-        messaging_properties = kwargs.get('messaging_properties')        
+        messaging_properties = kwargs.get('messaging_properties')
         self.bootstrap_servers = messaging_properties.connection_address
         if self.bootstrap_servers is None:
             raise ValueError('connection_address not set on messaging_properties')

--- a/ignition/service/messaging.py
+++ b/ignition/service/messaging.py
@@ -217,7 +217,6 @@ class KafkaDeliveryService(Service, DeliveryCapability):
             self.producer = KafkaProducer(**config)
     
     def __close_producer(self):
-        print("Closing Producer")
         self.producer.flush()
         self.producer.close()
 

--- a/tests/unit/service/test_messaging.py
+++ b/tests/unit/service/test_messaging.py
@@ -144,7 +144,7 @@ class TestKafkaInboxService(unittest.TestCase):
             mock_read_inbox_func.assert_called_once_with(mock_record_1.value.decode.return_value)
             mock_kafka_consumer.commit.assert_called_once()
             ready_for_second_message = True
-            time.sleep(0.01)
+            time.sleep(1)
             mock_record_2.value.decode.assert_called_once_with('utf-8')
             mock_read_inbox_func.assert_called_with(mock_record_2.value.decode.return_value)
             mock_kafka_consumer.commit.assert_has_calls([call(), call()])


### PR DESCRIPTION
Added producer.close() to messaging.py to close kafka producer in order to complete in-progress task during graceful shutdown for drivers.
This will prevent the kafka producer from timing out at 0 seconds


Issue link : https://github.ibm.com/TNC/tnc-o-tracking/issues/2509

Build Success Screenshot :  
![image](https://user-images.githubusercontent.com/79189065/140280073-5d0f3588-a863-42c8-83a7-27af26adb15b.png)


Shutdown screenshot for kubedriver : 

<img width="1792" alt="Screenshot 2021-11-04 at 1 47 57 PM" src="https://user-images.githubusercontent.com/79189065/140280327-1bbd16c9-7d21-4dfa-9db8-6f1b92b34253.png">

Kubernetes instance screenshot on UI : 

<img width="1545" alt="Screenshot 2021-11-04 at 1 50 46 PM" src="https://user-images.githubusercontent.com/79189065/140280597-8b317594-8825-48a0-8d98-1d0ae138539a.png">


