### PR TITLE
Update Werkzeug BaseResponse to Response

### DIFF
--- a/ignition/api/exceptions.py
+++ b/ignition/api/exceptions.py
@@ -2,7 +2,7 @@ import json
 import inspect
 import logging
 from werkzeug.exceptions import HTTPException
-from werkzeug.wrappers import BaseResponse as Response
+from werkzeug.wrappers import Response
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
After the recent werkzeug update to 2.1.1 version, we need to  import `Response` instead of `BaseResponse` to support this update

- [x] Issue: #130 
- [x] List of related PRs. : None
- [x] Project builds without any errors.
- [x] Unit Tests updated (or created where needed) and all pass.
- [x] You have ran manual functional “smoke” test (does product as a whole still work?).
- [x] User Story meets the acceptance criteria - and passes. acceptance criteria should be understood at outset.
- [x] There is a PR for update of internal documentation for the affected Project(s) - README etc.
- [x] Description of the changes:  #130 