### PR TITLE
Issue 4515

### DIFF
--- a/ignition/boot/configurators/resourcedriverapi.py
+++ b/ignition/boot/configurators/resourcedriverapi.py
@@ -84,6 +84,8 @@ class ResourceDriverServicesConfigurator():
             required_capabilities = {}
             if resource_driver_config.async_messaging_enabled is True:
                 required_capabilities['lifecycle_monitor_service'] = LifecycleExecutionMonitoringCapability
+            else:
+                required_capabilities['lifecycle_messaging_service'] = LifecycleMessagingCapability
             required_capabilities['handler'] = ResourceDriverHandlerCapability
             required_capabilities['resource_driver_config'] = ResourceDriverProperties
             required_capabilities['driver_files_manager'] = DriverFilesManagerCapability

--- a/ignition/service/messaging.py
+++ b/ignition/service/messaging.py
@@ -238,7 +238,7 @@ class KafkaDeliveryService(Service, DeliveryCapability):
         logger.debug('Delivering envelope to {0} with message content: {1}'.format(envelope.address, content))
         if(hasattr(envelope, 'tenant_id')):
             tenant_id = envelope.tenant_id
-            headers = [('TenantId', envelope.tenant_id.encode('utf-8'))]
+            headers = [('tenantId', envelope.tenant_id.encode('utf-8'))]
             if key is None:
                 self.producer.send(envelope.address, content, headers=headers).add_callback(self.__on_send_success).add_errback(self.__on_send_error)
             else:

--- a/ignition/service/resourcedriver.py
+++ b/ignition/service/resourcedriver.py
@@ -295,7 +295,7 @@ class ResourceDriverService(Service, ResourceDriverServiceCapability):
             else:
                 if(isinstance(execute_response, LifecycleExecution)):
                     logger.info("Sending status to Kafka Topic immediately for non async task")
-                    self.lifecycle_messaging_service.send_lifecycle_execution(execute_response)
+                    self.lifecycle_messaging_service.send_lifecycle_execution(execute_response, tenant_id=tenant_id)
         return execute_response
 
     def find_reference(self, instance_name, driver_files, deployment_location):

--- a/ignition/service/resourcedriver.py
+++ b/ignition/service/resourcedriver.py
@@ -291,7 +291,7 @@ class ResourceDriverService(Service, ResourceDriverServiceCapability):
             associated_topology = AssociatedTopology.from_dict(associated_topology)
             execute_response = self.handler.execute_lifecycle(lifecycle_name, driver_files_tree, PropValueMap(system_properties), PropValueMap(resource_properties), PropValueMap(request_properties), associated_topology, deployment_location)
             if self.async_enabled is True:
-                self.__async_lifecycle_execution_completion(execute_response.request_id, deployment_location)
+                self.__async_lifecycle_execution_completion(execute_response.request_id, deployment_location, tenant_id)
             else:
                 if(isinstance(execute_response, LifecycleExecution)):
                     logger.info("Sending status to Kafka Topic immediately for non async task")

--- a/ignition/service/resourcedriver.py
+++ b/ignition/service/resourcedriver.py
@@ -200,9 +200,9 @@ class ResourceDriverApiService(Service, ResourceDriverApiCapability, BaseControl
             logging_context.set_from_headers()
 
             tenant_id=None
-            if('TenantId' in connexion.request.headers):
+            if('tenantId' in connexion.request.headers):
                 tenant_id = connexion.request.headers['TenantId']
-                logger.debug("TenantId received in headers : %s", tenant_id)
+                logger.debug("tenantId received in headers : %s", tenant_id)
 
             logger.debug("Value of tenant_id is %s", tenant_id)
             body = self.get_body(kwarg)

--- a/tests/unit/boot/configurators/test_resourcedriverapi.py
+++ b/tests/unit/boot/configurators/test_resourcedriverapi.py
@@ -138,7 +138,8 @@ class TestResourceDriverServicesConfigurator(ConfiguratorTestCase):
         ResourceDriverServicesConfigurator().configure(configuration, self.mock_service_register)
         service_registrations = self.assert_services_registered(1)
         self.assert_service_registration_equal(service_registrations[0], ServiceRegistration(ResourceDriverService, handler=ResourceDriverHandlerCapability,
-                                                                                             resource_driver_config=ResourceDriverProperties, driver_files_manager=DriverFilesManagerCapability))
+                                                                                             resource_driver_config=ResourceDriverProperties, driver_files_manager=DriverFilesManagerCapability,
+                                                                                             lifecycle_messaging_service=LifecycleMessagingCapability))
 
     def test_configure_service_fails_when_already_registered(self):
         configuration = self.__bootstrap_config()

--- a/tests/unit/service/test_resourcedriver.py
+++ b/tests/unit/service/test_resourcedriver.py
@@ -270,8 +270,10 @@ class TestResourceDriverService(unittest.TestCase):
         mock_resource_driver_config = MagicMock()
         mock_resource_driver_config.async_messaging_enabled = False
         mock_resource_driver_config.lifecycle_request_queue.enabled = True
+        mock_lifecycle_messaging_service = MagicMock()
         with self.assertRaises(ValueError) as context:
-            ResourceDriverService(handler=mock_service_driver, resource_driver_config=mock_resource_driver_config, driver_files_manager=mock_driver_files_manager)
+            ResourceDriverService(handler=mock_service_driver, resource_driver_config=mock_resource_driver_config, driver_files_manager=mock_driver_files_manager,
+                                  lifecycle_messaging_service=mock_lifecycle_messaging_service)
         self.assertEqual(str(context.exception), 'lifecycle_request_queue argument not provided (required when lifecycle_request_queue.enabled is True)')
 
     def test_execute_with_request_queue(self):
@@ -281,7 +283,9 @@ class TestResourceDriverService(unittest.TestCase):
         mock_resource_driver_config = MagicMock()
         mock_resource_driver_config.async_messaging_enabled = False
         mock_resource_driver_config.lifecycle_request_queue.enabled = True
-        service = ResourceDriverService(handler=mock_service_driver, resource_driver_config=mock_resource_driver_config, driver_files_manager=mock_driver_files_manager, lifecycle_request_queue=mock_request_queue)
+        mock_lifecycle_messaging_service = MagicMock()
+        service = ResourceDriverService(handler=mock_service_driver, resource_driver_config=mock_resource_driver_config, driver_files_manager=mock_driver_files_manager, lifecycle_request_queue=mock_request_queue,
+                                        lifecycle_messaging_service=mock_lifecycle_messaging_service)
         lifecycle_name = 'Install'
         driver_files = '123'
         system_properties = {'resourceId': '1', 'otherProp': 1}
@@ -315,7 +319,9 @@ class TestResourceDriverService(unittest.TestCase):
         mock_driver_files_manager.build_tree.return_value = mock_script_tree
         mock_resource_driver_config = MagicMock()
         mock_resource_driver_config.lifecycle_request_queue.enabled = False
-        service = ResourceDriverService(handler=mock_service_driver, resource_driver_config=mock_resource_driver_config, driver_files_manager=mock_driver_files_manager)
+        mock_lifecycle_messaging_service = MagicMock()
+        service = ResourceDriverService(handler=mock_service_driver, resource_driver_config=mock_resource_driver_config, driver_files_manager=mock_driver_files_manager,
+                                        lifecycle_messaging_service=mock_lifecycle_messaging_service)
         lifecycle_name = 'start'
         driver_files = b'123'
         system_properties = self.__propvaluemap({'resourceId': '999', 'otherProp': 1})
@@ -336,7 +342,9 @@ class TestResourceDriverService(unittest.TestCase):
         mock_driver_files_manager.build_tree.return_value = mock_script_tree
         mock_resource_driver_config = MagicMock()
         mock_resource_driver_config.lifecycle_request_queue.enabled = False
-        service = ResourceDriverService(handler=mock_service_driver, resource_driver_config=mock_resource_driver_config, driver_files_manager=mock_driver_files_manager)
+        mock_lifecycle_messaging_service = MagicMock()
+        service = ResourceDriverService(handler=mock_service_driver, resource_driver_config=mock_resource_driver_config, driver_files_manager=mock_driver_files_manager,
+                                        lifecycle_messaging_service=mock_lifecycle_messaging_service)
         lifecycle_name = 'start'
         driver_files = b'123'
         system_properties = {'resourceId': '999', 'otherProp': 1}
@@ -380,7 +388,9 @@ class TestResourceDriverService(unittest.TestCase):
         mock_driver_files_manager.build_tree.return_value = mock_script_tree
         mock_resource_driver_config = MagicMock()
         mock_resource_driver_config.lifecycle_request_queue.enabled = False
-        service = ResourceDriverService(handler=mock_service_driver, resource_driver_config=mock_resource_driver_config, driver_files_manager=mock_driver_files_manager)
+        mock_lifecycle_messaging_service = MagicMock()
+        service = ResourceDriverService(handler=mock_service_driver, resource_driver_config=mock_resource_driver_config, driver_files_manager=mock_driver_files_manager,
+                                        lifecycle_messaging_service=mock_lifecycle_messaging_service)
         lifecycle_name = 'start'
         driver_files = b'123'
         deployment_location = {'name': 'TestDl'}
@@ -397,7 +407,9 @@ class TestResourceDriverService(unittest.TestCase):
         mock_driver_files_manager.build_tree.return_value = mock_script_tree
         mock_resource_driver_config = MagicMock()
         mock_resource_driver_config.lifecycle_request_queue.enabled = False
-        service = ResourceDriverService(handler=mock_service_driver, resource_driver_config=mock_resource_driver_config, driver_files_manager=mock_driver_files_manager)
+        mock_lifecycle_messaging_service = MagicMock()
+        service = ResourceDriverService(handler=mock_service_driver, resource_driver_config=mock_resource_driver_config, driver_files_manager=mock_driver_files_manager,
+                                        lifecycle_messaging_service=mock_lifecycle_messaging_service)
         lifecycle_name = 'start'
         driver_files = b'123'
         deployment_location = {'name': 'TestDl'}


### PR DESCRIPTION
# Pull Request Review

## Checklist

- [x] Issue: https://github.com/IBM/ignition/issues/136
- [x] List of related PRs : https://github.com/IBM/netconf-driver/pull/10
- [x] Project builds without any errors.
- [x] Unit Tests - all pass.
- [x] Ran manual functional “smoke” test (does product as a whole still work?).
- [x] User Story meets the acceptance criteria - and passes. acceptance criteria should be understood at outset.
- [x]  **Description of the changes**:  Generally for most of the drivers, execute_lifecycle() would return some acknowledgement as a response, then a background thread is started to monitor the execution by calling get_lifecycle_execution(). On the basis of that the driver would have a way to check the status of the request. But in some cases (Netconf Driver), the result is coming back immediately and so we can call lifecycle_messaging_service.send_lifecycle_execution immediately when async_enabled is false.