### PR TITLE
Issue 137

### DIFF
--- a/ignition/service/messaging.py
+++ b/ignition/service/messaging.py
@@ -238,7 +238,7 @@ class KafkaDeliveryService(Service, DeliveryCapability):
         logger.debug('Delivering envelope to {0} with message content: {1}'.format(envelope.address, content))
         if(hasattr(envelope, 'tenant_id')):
             tenant_id = envelope.tenant_id
-            headers = [('tenant_id', envelope.tenant_id.encode('utf-8'))]
+            headers = [('TenantId', envelope.tenant_id.encode('utf-8'))]
             if key is None:
                 self.producer.send(envelope.address, content, headers=headers).add_callback(self.__on_send_success).add_errback(self.__on_send_error)
             else:

--- a/ignition/service/resourcedriver.py
+++ b/ignition/service/resourcedriver.py
@@ -199,7 +199,6 @@ class ResourceDriverApiService(Service, ResourceDriverApiCapability, BaseControl
         try:
             logging_context.set_from_headers()
 
-            logger.debug("Fetching tenant_id ... ")
             tenant_id=None
             if('TenantId' in connexion.request.headers):
                 tenant_id = connexion.request.headers['TenantId']

--- a/ignition/service/resourcedriver.py
+++ b/ignition/service/resourcedriver.py
@@ -199,12 +199,13 @@ class ResourceDriverApiService(Service, ResourceDriverApiCapability, BaseControl
         try:
             logging_context.set_from_headers()
 
+            logger.debug("Fetching tenant_id ... ")
+            tenant_id=None
             if('TenantId' in connexion.request.headers):
                 tenant_id = connexion.request.headers['TenantId']
                 logger.info("TenantId received in headers : %s", tenant_id)
-            else:
-                raise InvalidRequestError('tenant_id has not been provided')
 
+            logger.info("Value of tenant_id is %s", tenant_id)
             body = self.get_body(kwarg)
             logger.debug('Handling lifecycle execution request with body %s', body)
             lifecycle_name = self.get_body_required_field(body, 'lifecycleName')
@@ -277,6 +278,7 @@ class ResourceDriverService(Service, ResourceDriverServiceCapability):
                 'request_properties': request_properties,
                 'associated_topology': associated_topology,
                 'deployment_location': deployment_location,
+                'tenant_id': tenant_id,
                 'logging_context': dict(logging_context.get_all())
             })
             execute_response = LifecycleExecuteResponse(request_id)

--- a/ignition/service/resourcedriver.py
+++ b/ignition/service/resourcedriver.py
@@ -202,9 +202,9 @@ class ResourceDriverApiService(Service, ResourceDriverApiCapability, BaseControl
             tenant_id=None
             if('TenantId' in connexion.request.headers):
                 tenant_id = connexion.request.headers['TenantId']
-                logger.info("TenantId received in headers : %s", tenant_id)
+                logger.debug("TenantId received in headers : %s", tenant_id)
 
-            logger.info("Value of tenant_id is %s", tenant_id)
+            logger.debug("Value of tenant_id is %s", tenant_id)
             body = self.get_body(kwarg)
             logger.debug('Handling lifecycle execution request with body %s', body)
             lifecycle_name = self.get_body_required_field(body, 'lifecycleName')

--- a/tests/unit/service/test_resourcedriver.py
+++ b/tests/unit/service/test_resourcedriver.py
@@ -14,6 +14,7 @@ import tempfile
 import shutil
 import base64
 from ignition.utils.propvaluemap import PropValueMap
+from flask import Flask
 
 class TestResourceDriverApiService(unittest.TestCase):
 
@@ -39,89 +40,124 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service = MagicMock()
         mock_service.execute_lifecycle.return_value = LifecycleExecuteResponse('123')
         controller = ResourceDriverApiService(service=mock_service)
-        response, code = controller.execute_lifecycle(**{
-            'body': {
-                'lifecycleName': 'Start',
-                'systemProperties': self.__props_with_types({'resourceId': '1', 'b': 1}),
-                'resourceProperties': self.__props_with_types({'a': '2', 'b': 2}),
-                'requestProperties': self.__props_with_types({'reqA': '3', 'reqB': True}),
-                'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
-                'driverFiles': b'123',
-                'deploymentLocation': {'name': 'test'},
-                'version': '1.0.0'
-            }
-        })
+        app = Flask(__name__)
+        with app.test_request_context():
+            response, code = controller.execute_lifecycle(**{
+                'body': {
+                    'lifecycleName': 'Start',
+                    'systemProperties': self.__props_with_types({'resourceId': '1', 'b': 1}),
+                    'resourceProperties': self.__props_with_types({'a': '2', 'b': 2}),
+                    'requestProperties': self.__props_with_types({'reqA': '3', 'reqB': True}),
+                    'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
+                    'driverFiles': b'123',
+                    'deploymentLocation': {'name': 'test'},
+                    'version': '1.0.0'
+                }
+            })
         mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}, 'b': { 'type': 'integer', 'value': 1} }, {'a': { 'type': 'string', 'value': '2'}, 'b': { 'type': 'integer', 'value': 2}}, {'reqA': {'type': 'string', 'value': '3'}, 'reqB': {'type': 'boolean', 'value': True}}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'})
         self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
         self.assertEqual(code, 202)
         logging_context.set_from_headers.assert_called_once()
 
     @patch('ignition.service.resourcedriver.logging_context')
+    def test_execute_with_tenant_id(self, logging_context):
+        mock_service = MagicMock()
+        mock_service.execute_lifecycle.return_value = LifecycleExecuteResponse('123')
+        controller = ResourceDriverApiService(service=mock_service)
+        app = Flask(__name__)
+        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
+            response, code, response_headers = controller.execute_lifecycle(**{
+                'body': {
+                    'lifecycleName': 'Start',
+                    'systemProperties': self.__props_with_types({'resourceId': '1', 'b': 1}),
+                    'resourceProperties': self.__props_with_types({'a': '2', 'b': 2}),
+                    'requestProperties': self.__props_with_types({'reqA': '3', 'reqB': True}),
+                    'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
+                    'driverFiles': b'123',
+                    'deploymentLocation': {'name': 'test'},
+                    'version': '1.0.0'
+                }
+            })
+        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}, 'b': { 'type': 'integer', 'value': 1} }, {'a': { 'type': 'string', 'value': '2'}, 'b': { 'type': 'integer', 'value': 2}}, {'reqA': {'type': 'string', 'value': '3'}, 'reqB': {'type': 'boolean', 'value': True}}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'})
+        self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
+        self.assertEqual(code, 202)
+        self.assertEqual(response_headers, {'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'})
+        logging_context.set_from_headers.assert_called_once()
+
+    @patch('ignition.service.resourcedriver.logging_context')
     def test_execute_missing_lifecycle_name(self, logging_context):
         mock_service = MagicMock()
         controller = ResourceDriverApiService(service=mock_service)
-        with self.assertRaises(BadRequest) as context:
-            controller.execute_lifecycle(**{
-                'body': {
-                    'systemProperties': self.__props_with_types({'resourceId': '1'}),
-                    'resourceProperties': self.__props_with_types({'a': '2'}),
-                    'requestProperties': self.__props_with_types({'reqA': '3'}),
-                    'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
-                    'driverFiles': b'123',
-                    'deploymentLocation': {'name': 'test'}
-                }
-            })
+        app = Flask(__name__)
+        with app.test_request_context():
+            with self.assertRaises(BadRequest) as context:
+                controller.execute_lifecycle(**{
+                    'body': {
+                        'systemProperties': self.__props_with_types({'resourceId': '1'}),
+                        'resourceProperties': self.__props_with_types({'a': '2'}),
+                        'requestProperties': self.__props_with_types({'reqA': '3'}),
+                        'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
+                        'driverFiles': b'123',
+                        'deploymentLocation': {'name': 'test'}
+                    }
+                })
         self.assertEqual(str(context.exception), '\'lifecycleName\' is a required field but was not found in the request data body')
 
     @patch('ignition.service.resourcedriver.logging_context')
     def test_execute_missing_driver_files(self, logging_context):
         mock_service = MagicMock()
         controller = ResourceDriverApiService(service=mock_service)
-        with self.assertRaises(BadRequest) as context:
-            controller.execute_lifecycle(**{
-                'body': {
-                    'lifecycleName': 'Start',
-                    'systemProperties': self.__props_with_types({'resourceId': '1'}),
-                    'resourceProperties': self.__props_with_types({'a': '2'}),
-                    'requestProperties': self.__props_with_types({'reqA': '3'}),
-                    'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
-                    'deploymentLocation': {'name': 'test'}
-                }
-            })
+        app = Flask(__name__)
+        with app.test_request_context():
+            with self.assertRaises(BadRequest) as context:
+                controller.execute_lifecycle(**{
+                    'body': {
+                        'lifecycleName': 'Start',
+                        'systemProperties': self.__props_with_types({'resourceId': '1'}),
+                        'resourceProperties': self.__props_with_types({'a': '2'}),
+                        'requestProperties': self.__props_with_types({'reqA': '3'}),
+                        'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
+                        'deploymentLocation': {'name': 'test'}
+                    }
+                })
         self.assertEqual(str(context.exception), '\'driverFiles\' is a required field but was not found in the request data body')
 
     @patch('ignition.service.resourcedriver.logging_context')
     def test_execute_missing_deployment_location(self, logging_context):
         mock_service = MagicMock()
         controller = ResourceDriverApiService(service=mock_service)
-        with self.assertRaises(BadRequest) as context:
-            controller.execute_lifecycle(**{
-                'body': {
-                    'lifecycleName': 'Start',
-                    'systemProperties': self.__props_with_types({'resourceId': '1'}),
-                    'resourceProperties': self.__props_with_types({'a': '2'}),
-                    'requestProperties': self.__props_with_types({'reqA': '3'}),
-                    'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
-                    'driverFiles': b'123'
-                }
-            })
+        app = Flask(__name__)
+        with app.test_request_context():
+            with self.assertRaises(BadRequest) as context:
+                controller.execute_lifecycle(**{
+                    'body': {
+                        'lifecycleName': 'Start',
+                        'systemProperties': self.__props_with_types({'resourceId': '1'}),
+                        'resourceProperties': self.__props_with_types({'a': '2'}),
+                        'requestProperties': self.__props_with_types({'reqA': '3'}),
+                        'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
+                        'driverFiles': b'123'
+                    }
+                })
         self.assertEqual(str(context.exception), '\'deploymentLocation\' is a required field but was not found in the request data body')
 
     @patch('ignition.service.resourcedriver.logging_context')
     def test_execute_missing_system_properties(self, logging_context):
         mock_service = MagicMock()
         controller = ResourceDriverApiService(service=mock_service)
-        with self.assertRaises(BadRequest) as context:
-            controller.execute_lifecycle(**{
-                'body': {
-                    'lifecycleName': 'Start',
-                    'resourceProperties': self.__props_with_types({'a': '2'}),
-                    'requestProperties': self.__props_with_types({'reqA': '3'}),
-                    'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
-                    'driverFiles': b'123',
-                    'deploymentLocation': {'name': 'test'}
-                }
-            })
+        app = Flask(__name__)
+        with app.test_request_context():
+            with self.assertRaises(BadRequest) as context:
+                controller.execute_lifecycle(**{
+                    'body': {
+                        'lifecycleName': 'Start',
+                        'resourceProperties': self.__props_with_types({'a': '2'}),
+                        'requestProperties': self.__props_with_types({'reqA': '3'}),
+                        'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
+                        'driverFiles': b'123',
+                        'deploymentLocation': {'name': 'test'}
+                    }
+                })
         self.assertEqual(str(context.exception), '\'systemProperties\' is a required field but was not found in the request data body')
 
     @patch('ignition.service.resourcedriver.logging_context')
@@ -129,17 +165,19 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service = MagicMock()
         mock_service.execute_lifecycle.return_value = LifecycleExecuteResponse('123')
         controller = ResourceDriverApiService(service=mock_service)
-        response, code = controller.execute_lifecycle(**{
-            'body': {
-                'lifecycleName': 'Start',
-                'systemProperties': self.__props_with_types({'resourceId': '1'}),
-                'requestProperties': self.__props_with_types({'reqA': '3'}),
-                'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
-                'driverFiles': b'123',
-                'deploymentLocation': {'name': 'test'},
-                'version': '1.0.0'
-            }
-        })
+        app = Flask(__name__)
+        with app.test_request_context():
+            response, code = controller.execute_lifecycle(**{
+                'body': {
+                    'lifecycleName': 'Start',
+                    'systemProperties': self.__props_with_types({'resourceId': '1'}),
+                    'requestProperties': self.__props_with_types({'reqA': '3'}),
+                    'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
+                    'driverFiles': b'123',
+                    'deploymentLocation': {'name': 'test'},
+                    'version': '1.0.0'
+                }
+            })
         mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}}, {}, {'reqA': {'type': 'string', 'value': '3'}}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'})
         self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
         self.assertEqual(code, 202)
@@ -149,17 +187,19 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service = MagicMock()
         mock_service.execute_lifecycle.return_value = LifecycleExecuteResponse('123')
         controller = ResourceDriverApiService(service=mock_service)
-        response, code = controller.execute_lifecycle(**{
-            'body': {
-                'lifecycleName': 'Start',
-                'systemProperties': self.__props_with_types({'resourceId': '1'}),
-                'resourceProperties': self.__props_with_types({'a': '2'}),
-                'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
-                'driverFiles': b'123',
-                'deploymentLocation': {'name': 'test'},
-                'version': '1.0.0'
-            }
-        })
+        app = Flask(__name__)
+        with app.test_request_context():
+            response, code = controller.execute_lifecycle(**{
+                'body': {
+                    'lifecycleName': 'Start',
+                    'systemProperties': self.__props_with_types({'resourceId': '1'}),
+                    'resourceProperties': self.__props_with_types({'a': '2'}),
+                    'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
+                    'driverFiles': b'123',
+                    'deploymentLocation': {'name': 'test'},
+                    'version': '1.0.0'
+                }
+            })
         mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}}, {'a': { 'type': 'string', 'value': '2'}}, {}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'})
         self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
         self.assertEqual(code, 202)
@@ -169,17 +209,19 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service = MagicMock()
         mock_service.execute_lifecycle.return_value = LifecycleExecuteResponse('123')
         controller = ResourceDriverApiService(service=mock_service)
-        response, code = controller.execute_lifecycle(**{
-            'body': {
-                'lifecycleName': 'Start',
-                'systemProperties': self.__props_with_types({'resourceId': '1'}),
-                'resourceProperties': self.__props_with_types({'a': '2'}),
-                'requestProperties': self.__props_with_types({'reqA': '3'}),
-                'driverFiles': b'123',
-                'deploymentLocation': {'name': 'test'},
-                'version': '1.0.0'
-            }
-        })
+        app = Flask(__name__)
+        with app.test_request_context():
+            response, code = controller.execute_lifecycle(**{
+                'body': {
+                    'lifecycleName': 'Start',
+                    'systemProperties': self.__props_with_types({'resourceId': '1'}),
+                    'resourceProperties': self.__props_with_types({'a': '2'}),
+                    'requestProperties': self.__props_with_types({'reqA': '3'}),
+                    'driverFiles': b'123',
+                    'deploymentLocation': {'name': 'test'},
+                    'version': '1.0.0'
+                }
+            })
         mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}}, {'a': { 'type': 'string', 'value': '2'}}, {'reqA': {'type': 'string', 'value': '3'}}, {}, {'name': 'test'})
         self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
         self.assertEqual(code, 202)

--- a/tests/unit/service/test_resourcedriver.py
+++ b/tests/unit/service/test_resourcedriver.py
@@ -41,8 +41,8 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service.execute_lifecycle.return_value = LifecycleExecuteResponse('123')
         controller = ResourceDriverApiService(service=mock_service)
         app = Flask(__name__)
-        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
-            response, code, response_headers = controller.execute_lifecycle(**{
+        with app.test_request_context():
+            response, code = controller.execute_lifecycle(**{
                 'body': {
                     'lifecycleName': 'Start',
                     'systemProperties': self.__props_with_types({'resourceId': '1', 'b': 1}),
@@ -54,10 +54,9 @@ class TestResourceDriverApiService(unittest.TestCase):
                     'version': '1.0.0'
                 }
             })
-        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}, 'b': { 'type': 'integer', 'value': 1} }, {'a': { 'type': 'string', 'value': '2'}, 'b': { 'type': 'integer', 'value': 2}}, {'reqA': {'type': 'string', 'value': '3'}, 'reqB': {'type': 'boolean', 'value': True}}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'}, '5d1cd9ca-f6d9-11ec-8084-00000a0b651c')
+        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}, 'b': { 'type': 'integer', 'value': 1} }, {'a': { 'type': 'string', 'value': '2'}, 'b': { 'type': 'integer', 'value': 2}}, {'reqA': {'type': 'string', 'value': '3'}, 'reqB': {'type': 'boolean', 'value': True}}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'}, None)
         self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
         self.assertEqual(code, 202)
-        self.assertEqual(response_headers, {'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'})
         logging_context.set_from_headers.assert_called_once()
 
     @patch('ignition.service.resourcedriver.logging_context')
@@ -65,7 +64,7 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service = MagicMock()
         controller = ResourceDriverApiService(service=mock_service)
         app = Flask(__name__)
-        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
+        with app.test_request_context():
             with self.assertRaises(BadRequest) as context:
                 controller.execute_lifecycle(**{
                     'body': {
@@ -84,7 +83,7 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service = MagicMock()
         controller = ResourceDriverApiService(service=mock_service)
         app = Flask(__name__)
-        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
+        with app.test_request_context():
             with self.assertRaises(BadRequest) as context:
                 controller.execute_lifecycle(**{
                     'body': {
@@ -103,7 +102,7 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service = MagicMock()
         controller = ResourceDriverApiService(service=mock_service)
         app = Flask(__name__)
-        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
+        with app.test_request_context():
             with self.assertRaises(BadRequest) as context:
                 controller.execute_lifecycle(**{
                     'body': {
@@ -122,7 +121,7 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service = MagicMock()
         controller = ResourceDriverApiService(service=mock_service)
         app = Flask(__name__)
-        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
+        with app.test_request_context():
             with self.assertRaises(BadRequest) as context:
                 controller.execute_lifecycle(**{
                     'body': {
@@ -142,8 +141,8 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service.execute_lifecycle.return_value = LifecycleExecuteResponse('123')
         controller = ResourceDriverApiService(service=mock_service)
         app = Flask(__name__)
-        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
-            response, code, response_headers = controller.execute_lifecycle(**{
+        with app.test_request_context():
+            response, code = controller.execute_lifecycle(**{
                 'body': {
                     'lifecycleName': 'Start',
                     'systemProperties': self.__props_with_types({'resourceId': '1'}),
@@ -154,10 +153,9 @@ class TestResourceDriverApiService(unittest.TestCase):
                     'version': '1.0.0'
                 }
             })
-        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}}, {}, {'reqA': {'type': 'string', 'value': '3'}}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'}, '5d1cd9ca-f6d9-11ec-8084-00000a0b651c')
+        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}}, {}, {'reqA': {'type': 'string', 'value': '3'}}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'}, None)
         self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
         self.assertEqual(code, 202)
-        self.assertEqual(response_headers, {'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'})
 
     @patch('ignition.service.resourcedriver.logging_context')
     def test_execute_missing_request_properties(self, logging_context):
@@ -165,8 +163,8 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service.execute_lifecycle.return_value = LifecycleExecuteResponse('123')
         controller = ResourceDriverApiService(service=mock_service)
         app = Flask(__name__)
-        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
-            response, code, response_headers = controller.execute_lifecycle(**{
+        with app.test_request_context():
+            response, code = controller.execute_lifecycle(**{
                 'body': {
                     'lifecycleName': 'Start',
                     'systemProperties': self.__props_with_types({'resourceId': '1'}),
@@ -177,10 +175,9 @@ class TestResourceDriverApiService(unittest.TestCase):
                     'version': '1.0.0'
                 }
             })
-        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}}, {'a': { 'type': 'string', 'value': '2'}}, {}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'}, '5d1cd9ca-f6d9-11ec-8084-00000a0b651c')
+        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}}, {'a': { 'type': 'string', 'value': '2'}}, {}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'}, None)
         self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
         self.assertEqual(code, 202)
-        self.assertEqual(response_headers, {'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'})
 
     @patch('ignition.service.resourcedriver.logging_context')
     def test_execute_missing_associated_topology(self, logging_context):
@@ -188,8 +185,8 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service.execute_lifecycle.return_value = LifecycleExecuteResponse('123')
         controller = ResourceDriverApiService(service=mock_service)
         app = Flask(__name__)
-        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
-            response, code, response_headers = controller.execute_lifecycle(**{
+        with app.test_request_context():
+            response, code = controller.execute_lifecycle(**{
                 'body': {
                     'lifecycleName': 'Start',
                     'systemProperties': self.__props_with_types({'resourceId': '1'}),
@@ -200,10 +197,9 @@ class TestResourceDriverApiService(unittest.TestCase):
                     'version': '1.0.0'
                 }
             })
-        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}}, {'a': { 'type': 'string', 'value': '2'}}, {'reqA': {'type': 'string', 'value': '3'}}, {}, {'name': 'test'}, '5d1cd9ca-f6d9-11ec-8084-00000a0b651c')
+        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}}, {'a': { 'type': 'string', 'value': '2'}}, {'reqA': {'type': 'string', 'value': '3'}}, {}, {'name': 'test'}, None)
         self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
         self.assertEqual(code, 202)
-        self.assertEqual(response_headers, {'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'})
 
     @patch('ignition.service.resourcedriver.logging_context')
     def test_execute_with_tenant_id(self, logging_context):

--- a/tests/unit/service/test_resourcedriver.py
+++ b/tests/unit/service/test_resourcedriver.py
@@ -41,8 +41,8 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service.execute_lifecycle.return_value = LifecycleExecuteResponse('123')
         controller = ResourceDriverApiService(service=mock_service)
         app = Flask(__name__)
-        with app.test_request_context():
-            response, code = controller.execute_lifecycle(**{
+        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
+            response, code, response_headers = controller.execute_lifecycle(**{
                 'body': {
                     'lifecycleName': 'Start',
                     'systemProperties': self.__props_with_types({'resourceId': '1', 'b': 1}),
@@ -54,9 +54,10 @@ class TestResourceDriverApiService(unittest.TestCase):
                     'version': '1.0.0'
                 }
             })
-        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}, 'b': { 'type': 'integer', 'value': 1} }, {'a': { 'type': 'string', 'value': '2'}, 'b': { 'type': 'integer', 'value': 2}}, {'reqA': {'type': 'string', 'value': '3'}, 'reqB': {'type': 'boolean', 'value': True}}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'})
+        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}, 'b': { 'type': 'integer', 'value': 1} }, {'a': { 'type': 'string', 'value': '2'}, 'b': { 'type': 'integer', 'value': 2}}, {'reqA': {'type': 'string', 'value': '3'}, 'reqB': {'type': 'boolean', 'value': True}}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'}, '5d1cd9ca-f6d9-11ec-8084-00000a0b651c')
         self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
         self.assertEqual(code, 202)
+        self.assertEqual(response_headers, {'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'})
         logging_context.set_from_headers.assert_called_once()
 
     @patch('ignition.service.resourcedriver.logging_context')
@@ -64,7 +65,7 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service = MagicMock()
         controller = ResourceDriverApiService(service=mock_service)
         app = Flask(__name__)
-        with app.test_request_context():
+        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
             with self.assertRaises(BadRequest) as context:
                 controller.execute_lifecycle(**{
                     'body': {
@@ -83,7 +84,7 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service = MagicMock()
         controller = ResourceDriverApiService(service=mock_service)
         app = Flask(__name__)
-        with app.test_request_context():
+        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
             with self.assertRaises(BadRequest) as context:
                 controller.execute_lifecycle(**{
                     'body': {
@@ -102,7 +103,7 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service = MagicMock()
         controller = ResourceDriverApiService(service=mock_service)
         app = Flask(__name__)
-        with app.test_request_context():
+        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
             with self.assertRaises(BadRequest) as context:
                 controller.execute_lifecycle(**{
                     'body': {
@@ -121,7 +122,7 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service = MagicMock()
         controller = ResourceDriverApiService(service=mock_service)
         app = Flask(__name__)
-        with app.test_request_context():
+        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
             with self.assertRaises(BadRequest) as context:
                 controller.execute_lifecycle(**{
                     'body': {
@@ -141,8 +142,8 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service.execute_lifecycle.return_value = LifecycleExecuteResponse('123')
         controller = ResourceDriverApiService(service=mock_service)
         app = Flask(__name__)
-        with app.test_request_context():
-            response, code = controller.execute_lifecycle(**{
+        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
+            response, code, response_headers = controller.execute_lifecycle(**{
                 'body': {
                     'lifecycleName': 'Start',
                     'systemProperties': self.__props_with_types({'resourceId': '1'}),
@@ -153,9 +154,10 @@ class TestResourceDriverApiService(unittest.TestCase):
                     'version': '1.0.0'
                 }
             })
-        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}}, {}, {'reqA': {'type': 'string', 'value': '3'}}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'})
+        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}}, {}, {'reqA': {'type': 'string', 'value': '3'}}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'}, '5d1cd9ca-f6d9-11ec-8084-00000a0b651c')
         self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
         self.assertEqual(code, 202)
+        self.assertEqual(response_headers, {'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'})
 
     @patch('ignition.service.resourcedriver.logging_context')
     def test_execute_missing_request_properties(self, logging_context):
@@ -163,8 +165,8 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service.execute_lifecycle.return_value = LifecycleExecuteResponse('123')
         controller = ResourceDriverApiService(service=mock_service)
         app = Flask(__name__)
-        with app.test_request_context():
-            response, code = controller.execute_lifecycle(**{
+        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
+            response, code, response_headers = controller.execute_lifecycle(**{
                 'body': {
                     'lifecycleName': 'Start',
                     'systemProperties': self.__props_with_types({'resourceId': '1'}),
@@ -175,9 +177,10 @@ class TestResourceDriverApiService(unittest.TestCase):
                     'version': '1.0.0'
                 }
             })
-        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}}, {'a': { 'type': 'string', 'value': '2'}}, {}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'})
+        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}}, {'a': { 'type': 'string', 'value': '2'}}, {}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'}, '5d1cd9ca-f6d9-11ec-8084-00000a0b651c')
         self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
         self.assertEqual(code, 202)
+        self.assertEqual(response_headers, {'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'})
 
     @patch('ignition.service.resourcedriver.logging_context')
     def test_execute_missing_associated_topology(self, logging_context):
@@ -185,8 +188,8 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service.execute_lifecycle.return_value = LifecycleExecuteResponse('123')
         controller = ResourceDriverApiService(service=mock_service)
         app = Flask(__name__)
-        with app.test_request_context():
-            response, code = controller.execute_lifecycle(**{
+        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
+            response, code, response_headers = controller.execute_lifecycle(**{
                 'body': {
                     'lifecycleName': 'Start',
                     'systemProperties': self.__props_with_types({'resourceId': '1'}),
@@ -197,9 +200,10 @@ class TestResourceDriverApiService(unittest.TestCase):
                     'version': '1.0.0'
                 }
             })
-        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}}, {'a': { 'type': 'string', 'value': '2'}}, {'reqA': {'type': 'string', 'value': '3'}}, {}, {'name': 'test'})
+        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}}, {'a': { 'type': 'string', 'value': '2'}}, {'reqA': {'type': 'string', 'value': '3'}}, {}, {'name': 'test'}, '5d1cd9ca-f6d9-11ec-8084-00000a0b651c')
         self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
         self.assertEqual(code, 202)
+        self.assertEqual(response_headers, {'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'})
 
     @patch('ignition.service.resourcedriver.logging_context')
     def test_execute_with_tenant_id(self, logging_context):
@@ -220,7 +224,7 @@ class TestResourceDriverApiService(unittest.TestCase):
                     'version': '1.0.0'
                 }
             })
-        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}, 'b': { 'type': 'integer', 'value': 1} }, {'a': { 'type': 'string', 'value': '2'}, 'b': { 'type': 'integer', 'value': 2}}, {'reqA': {'type': 'string', 'value': '3'}, 'reqB': {'type': 'boolean', 'value': True}}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'})
+        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}, 'b': { 'type': 'integer', 'value': 1} }, {'a': { 'type': 'string', 'value': '2'}, 'b': { 'type': 'integer', 'value': 2}}, {'reqA': {'type': 'string', 'value': '3'}, 'reqB': {'type': 'boolean', 'value': True}}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'}, '5d1cd9ca-f6d9-11ec-8084-00000a0b651c')
         self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
         self.assertEqual(code, 202)
         self.assertEqual(response_headers, {'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'})
@@ -331,7 +335,8 @@ class TestResourceDriverService(unittest.TestCase):
         request_properties = {'reqPropA': 'reqValueA', 'reqPropB': True}
         associated_topology = {'Test': {'id': '123', 'type': 'TestType'}}
         deployment_location = {'name': 'TestDl'}
-        result = service.execute_lifecycle(lifecycle_name, driver_files, system_properties, resource_properties, request_properties, associated_topology, deployment_location)
+        tenant_id = "123456"
+        result = service.execute_lifecycle(lifecycle_name, driver_files, system_properties, resource_properties, request_properties, associated_topology, deployment_location, tenant_id)
         self.assertIsNotNone(result.request_id)
         mock_service_driver.execute_lifecycle.assert_not_called()
         mock_request_queue.queue_lifecycle_request.assert_called_once()
@@ -365,7 +370,8 @@ class TestResourceDriverService(unittest.TestCase):
         request_properties = self.__propvaluemap({'reqPropA': 'reqValueA', 'reqPropB': True})
         associated_topology = {'Test': {'id': '123', 'type': 'TestType'}}
         deployment_location = {'name': 'TestDl'}
-        result = service.execute_lifecycle(lifecycle_name, driver_files, system_properties, resource_properties, request_properties, associated_topology, deployment_location)
+        tenant_id = "123456"
+        result = service.execute_lifecycle(lifecycle_name, driver_files, system_properties, resource_properties, request_properties, associated_topology, deployment_location, tenant_id)
         mock_service_driver.execute_lifecycle.assert_called_once_with(lifecycle_name, mock_script_tree, self.__propvaluemap(system_properties), self.__propvaluemap(resource_properties), self.__propvaluemap(request_properties), AssociatedTopology.from_dict(associated_topology), deployment_location)
         self.assertEqual(result, execute_response)
 
@@ -386,7 +392,8 @@ class TestResourceDriverService(unittest.TestCase):
         request_properties = {'reqPropA': 'reqValueA', 'reqPropB': True}
         associated_topology = {'Test': {'id': '123', 'type': 'TestType'}}
         deployment_location = {'name': 'TestDl'}
-        result = service.execute_lifecycle(lifecycle_name, driver_files, system_properties, resource_properties, request_properties, associated_topology, deployment_location)
+        tenant_id = "123456"
+        result = service.execute_lifecycle(lifecycle_name, driver_files, system_properties, resource_properties, request_properties, associated_topology, deployment_location, tenant_id)
         mock_driver_files_manager.build_tree.assert_called_once_with(ANY, driver_files)
         mock_service_driver.execute_lifecycle.assert_called_once_with(lifecycle_name, mock_script_tree, self.__propvaluemap(system_properties), self.__propvaluemap(resource_properties), self.__propvaluemap(request_properties), AssociatedTopology.from_dict(associated_topology), deployment_location)
         self.assertEqual(result, execute_response)
@@ -410,8 +417,9 @@ class TestResourceDriverService(unittest.TestCase):
         request_properties = {'reqPropA': 'reqValueA', 'reqPropB': True}
         associated_topology = {'Test': {'id': '123', 'type': 'TestType'}}
         deployment_location = {'name': 'TestDl'}
-        result = service.execute_lifecycle(lifecycle_name, driver_files, system_properties, resource_properties, request_properties, associated_topology, deployment_location)
-        mock_lifecycle_monitor_service.monitor_execution.assert_called_once_with('123', deployment_location)
+        tenant_id = "123456"
+        result = service.execute_lifecycle(lifecycle_name, driver_files, system_properties, resource_properties, request_properties, associated_topology, deployment_location, tenant_id)
+        mock_lifecycle_monitor_service.monitor_execution.assert_called_once_with('123', deployment_location, '123456')
 
     def test_find_uses_driver_handler(self):
         mock_service_driver = MagicMock()
@@ -475,23 +483,27 @@ class TestLifecycleExecutionMonitoringService(unittest.TestCase):
 
     def test_monitor_execution_schedules_job(self):
         monitoring_service = LifecycleExecutionMonitoringService(job_queue_service=self.mock_job_queue, lifecycle_messaging_service=self.mock_lifecycle_messaging_service, handler=self.mock_driver)
-        monitoring_service.monitor_execution('req123', {'name': 'TestDl'})
+        tenant_id = '123456'
+        monitoring_service.monitor_execution('req123', {'name': 'TestDl'}, tenant_id)
         self.mock_job_queue.queue_job.assert_called_once_with({
             'job_type': 'LifecycleExecutionMonitoring',
             'request_id': 'req123',
-            'deployment_location': {'name': 'TestDl'}
+            'deployment_location': {'name': 'TestDl'},
+            'tenant_id': '123456'
         })
 
     def test_monitor_execution_throws_error_when_request_id_is_none(self):
         monitoring_service = LifecycleExecutionMonitoringService(job_queue_service=self.mock_job_queue, lifecycle_messaging_service=self.mock_lifecycle_messaging_service, handler=self.mock_driver)
         with self.assertRaises(ValueError) as context:
-            monitoring_service.monitor_execution(None, {'name': 'TestDl'})
+            tenant_id = '123456'
+            monitoring_service.monitor_execution(None, {'name': 'TestDl'}, tenant_id)
         self.assertEqual(str(context.exception), 'Cannot monitor task when request_id is not given')
 
     def test_monitor_execution_throws_error_when_deployment_location_is_none(self):
         monitoring_service = LifecycleExecutionMonitoringService(job_queue_service=self.mock_job_queue, lifecycle_messaging_service=self.mock_lifecycle_messaging_service, handler=self.mock_driver)
         with self.assertRaises(ValueError) as context:
-            monitoring_service.monitor_execution('req123', None)
+            tenant_id = '123456'
+            monitoring_service.monitor_execution('req123', None, tenant_id)
         self.assertEqual(str(context.exception), 'Cannot monitor task when deployment_location is not given')
 
     def test_job_handler_does_not_mark_job_as_finished_if_in_progress(self):
@@ -500,7 +512,8 @@ class TestLifecycleExecutionMonitoringService(unittest.TestCase):
         job_finished = monitoring_service.job_handler({
             'job_type': 'LifecycleExecutionMonitoring',
             'request_id': 'req123',
-            'deployment_location': {'name': 'TestDl'}
+            'deployment_location': {'name': 'TestDl'},
+            'tenant_id': '123456'
         })
         self.assertEqual(job_finished, False)
         self.mock_driver.get_lifecycle_execution.assert_called_once_with('req123', {'name': 'TestDl'})
@@ -511,7 +524,8 @@ class TestLifecycleExecutionMonitoringService(unittest.TestCase):
         job_finished = monitoring_service.job_handler({
             'job_type': 'LifecycleExecutionMonitoring',
             'request_id': 'req123',
-            'deployment_location': {'name': 'TestDl'}
+            'deployment_location': {'name': 'TestDl'},
+            'tenant_id': '123456'
         })
         self.assertEqual(job_finished, False)
         self.mock_driver.get_lifecycle_execution.assert_called_once_with('req123', {'name': 'TestDl'})
@@ -522,7 +536,8 @@ class TestLifecycleExecutionMonitoringService(unittest.TestCase):
         job_finished = monitoring_service.job_handler({
             'job_type': 'LifecycleExecutionMonitoring',
             'request_id': 'req123',
-            'deployment_location': {'name': 'TestDl'}
+            'deployment_location': {'name': 'TestDl'},
+            'tenant_id': '123456'
         })
         self.assertEqual(job_finished, True)
         self.mock_driver.get_lifecycle_execution.assert_called_once_with('req123', {'name': 'TestDl'})
@@ -534,11 +549,12 @@ class TestLifecycleExecutionMonitoringService(unittest.TestCase):
         job_finished = monitoring_service.job_handler({
             'job_type': 'LifecycleExecutionMonitoring',
             'request_id': 'req123',
-            'deployment_location': {'name': 'TestDl'}
+            'deployment_location': {'name': 'TestDl'},
+            'tenant_id': '123456'
         })
         self.assertEqual(job_finished, True)
         self.mock_driver.get_lifecycle_execution.assert_called_once_with('req123', {'name': 'TestDl'})
-        self.mock_lifecycle_messaging_service.send_lifecycle_execution.assert_called_once_with(self.mock_driver.get_lifecycle_execution.return_value)
+        self.mock_lifecycle_messaging_service.send_lifecycle_execution.assert_called_once_with(self.mock_driver.get_lifecycle_execution.return_value, tenant_id='123456')
 
     def test_job_handler_sends_message_when_task_failed(self):
         self.mock_driver.get_lifecycle_execution.return_value = LifecycleExecution('req123', 'FAILED', None)
@@ -546,11 +562,12 @@ class TestLifecycleExecutionMonitoringService(unittest.TestCase):
         job_finished = monitoring_service.job_handler({
             'job_type': 'LifecycleExecutionMonitoring',
             'request_id': 'req123',
-            'deployment_location': {'name': 'TestDl'}
+            'deployment_location': {'name': 'TestDl'},
+            'tenant_id': '123456'
         })
         self.assertEqual(job_finished, True)
         self.mock_driver.get_lifecycle_execution.assert_called_once_with('req123', {'name': 'TestDl'})
-        self.mock_lifecycle_messaging_service.send_lifecycle_execution.assert_called_once_with(self.mock_driver.get_lifecycle_execution.return_value)
+        self.mock_lifecycle_messaging_service.send_lifecycle_execution.assert_called_once_with(self.mock_driver.get_lifecycle_execution.return_value, tenant_id='123456')
 
     def test_job_handler_ignores_job_without_request_id(self):
         monitoring_service = LifecycleExecutionMonitoringService(job_queue_service=self.mock_job_queue, lifecycle_messaging_service=self.mock_lifecycle_messaging_service, handler=self.mock_driver)

--- a/tests/unit/service/test_resourcedriver.py
+++ b/tests/unit/service/test_resourcedriver.py
@@ -60,31 +60,6 @@ class TestResourceDriverApiService(unittest.TestCase):
         logging_context.set_from_headers.assert_called_once()
 
     @patch('ignition.service.resourcedriver.logging_context')
-    def test_execute_with_tenant_id(self, logging_context):
-        mock_service = MagicMock()
-        mock_service.execute_lifecycle.return_value = LifecycleExecuteResponse('123')
-        controller = ResourceDriverApiService(service=mock_service)
-        app = Flask(__name__)
-        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
-            response, code, response_headers = controller.execute_lifecycle(**{
-                'body': {
-                    'lifecycleName': 'Start',
-                    'systemProperties': self.__props_with_types({'resourceId': '1', 'b': 1}),
-                    'resourceProperties': self.__props_with_types({'a': '2', 'b': 2}),
-                    'requestProperties': self.__props_with_types({'reqA': '3', 'reqB': True}),
-                    'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
-                    'driverFiles': b'123',
-                    'deploymentLocation': {'name': 'test'},
-                    'version': '1.0.0'
-                }
-            })
-        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}, 'b': { 'type': 'integer', 'value': 1} }, {'a': { 'type': 'string', 'value': '2'}, 'b': { 'type': 'integer', 'value': 2}}, {'reqA': {'type': 'string', 'value': '3'}, 'reqB': {'type': 'boolean', 'value': True}}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'})
-        self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
-        self.assertEqual(code, 202)
-        self.assertEqual(response_headers, {'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'})
-        logging_context.set_from_headers.assert_called_once()
-
-    @patch('ignition.service.resourcedriver.logging_context')
     def test_execute_missing_lifecycle_name(self, logging_context):
         mock_service = MagicMock()
         controller = ResourceDriverApiService(service=mock_service)
@@ -225,6 +200,31 @@ class TestResourceDriverApiService(unittest.TestCase):
         mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}}, {'a': { 'type': 'string', 'value': '2'}}, {'reqA': {'type': 'string', 'value': '3'}}, {}, {'name': 'test'})
         self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
         self.assertEqual(code, 202)
+
+    @patch('ignition.service.resourcedriver.logging_context')
+    def test_execute_with_tenant_id(self, logging_context):
+        mock_service = MagicMock()
+        mock_service.execute_lifecycle.return_value = LifecycleExecuteResponse('123')
+        controller = ResourceDriverApiService(service=mock_service)
+        app = Flask(__name__)
+        with app.test_request_context(headers={'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'}):
+            response, code, response_headers = controller.execute_lifecycle(**{
+                'body': {
+                    'lifecycleName': 'Start',
+                    'systemProperties': self.__props_with_types({'resourceId': '1', 'b': 1}),
+                    'resourceProperties': self.__props_with_types({'a': '2', 'b': 2}),
+                    'requestProperties': self.__props_with_types({'reqA': '3', 'reqB': True}),
+                    'associatedTopology': [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}],
+                    'driverFiles': b'123',
+                    'deploymentLocation': {'name': 'test'},
+                    'version': '1.0.0'
+                }
+            })
+        mock_service.execute_lifecycle.assert_called_once_with('Start', b'123', {'resourceId': { 'type': 'string', 'value': '1'}, 'b': { 'type': 'integer', 'value': 1} }, {'a': { 'type': 'string', 'value': '2'}, 'b': { 'type': 'integer', 'value': 2}}, {'reqA': {'type': 'string', 'value': '3'}, 'reqB': {'type': 'boolean', 'value': True}}, [{'id': 'abc', 'name': 'Test', 'type': 'Testing'}], {'name': 'test'})
+        self.assertEqual(response, {'requestId': '123', 'associatedTopology': {}, "version": "1.0.0"})
+        self.assertEqual(code, 202)
+        self.assertEqual(response_headers, {'TenantId': '5d1cd9ca-f6d9-11ec-8084-00000a0b651c'})
+        logging_context.set_from_headers.assert_called_once()
 
 class TestResourceDriverService(unittest.TestCase):
 


### PR DESCRIPTION
# Pull Request Review

## Checklist

- [x] **Issue**: https://github.com/IBM/ignition/issues/137
- [x] **List of related PRs** : https://github.com/IBM/ansible-lifecycle-driver/pull/169
- [x] **Project builds without any errors.**
- [x] **Unit Tests** - all pass.
- [x] **Ran manual functional “smoke” test (does product as a whole still work?)** : Yes, QA has validated the dev image and everything is working fine. They have uploaded the test results in IBM internal user stories.
- [x] **User Story meets the acceptance criteria** - and passes. acceptance criteria should be understood at outset.
- [x]  **Description of the changes**:  

Supporting TenantId for all the Lifecycle Drivers. As these drivers implement Ignition Framework we need to support from Ignition. In Request headers of execute lifecycle API, TenantId will be provided and same needs to be sent in Response Headers and Kafka Headers as well.
