### PR TITLE
Change OrderedDict to dict in ignition 

### DIFF
--- a/ignition/model/progress_events.py
+++ b/ignition/model/progress_events.py
@@ -18,8 +18,8 @@ class ResourceTransitionProgressEvent:
         return {}
 
     def to_dict(self):
-        return OrderedDict({
+        return {
             'eventType': BASE_EVENT_TYPE,
             'progressEventType': self.progress_event_type,
             'details': self._details()
-        })
+        }

--- a/tests/unit/model/test_progress_events.py
+++ b/tests/unit/model/test_progress_events.py
@@ -30,7 +30,6 @@ class TestResourceTransitionProgressEvent(unittest.TestCase):
     def test_to_dict(self):
         event = ResourceTransitionProgressEvent(progress_event_type='TestEvent')
         to_dict_result = event.to_dict()
-        self.assertIsInstance(to_dict_result, OrderedDict)
         self.assertEqual(to_dict_result['eventType'], 'ResourceTransitionProgressEvent')
         self.assertEqual(to_dict_result['progressEventType'], 'TestEvent')
         self.assertEqual(to_dict_result['details'], {})
@@ -38,13 +37,11 @@ class TestResourceTransitionProgressEvent(unittest.TestCase):
     def test_to_dict_order(self):
         event = ResourceTransitionProgressEvent(progress_event_type='TestEvent')
         to_dict_result = event.to_dict()
-        self.assertIsInstance(to_dict_result, OrderedDict)
         self.assertEqual(list(to_dict_result.keys()), ['eventType', 'progressEventType', 'details'])
 
     def test_to_dict_with_details(self):
         event = TestSubEvent(extra_details={'a': 'A', 'b': 'B'})
         to_dict_result = event.to_dict()
-        self.assertIsInstance(to_dict_result, OrderedDict)
         self.assertEqual(to_dict_result['eventType'], 'ResourceTransitionProgressEvent')
         self.assertEqual(to_dict_result['progressEventType'], 'TestSubEvent')
         self.assertEqual(to_dict_result['details'], {

--- a/tests/unit/service/test_progress_events.py
+++ b/tests/unit/service/test_progress_events.py
@@ -23,10 +23,10 @@ class TestProgressEventLogWriterService(unittest.TestCase):
         event = TestEvent(extra_details={'A': 123})
         self.service.add(event)
         expected_str = '---[{0}]---'.format(BASE_EVENT_TYPE)
-        expected_str += '\neventType: {0}'.format(BASE_EVENT_TYPE)
-        expected_str += '\nprogressEventType: TestEvent'
         expected_str += '\ndetails:'
-        expected_str += '\n  A: 123\n'
+        expected_str += '\n  A: 123'
+        expected_str += '\neventType: {0}'.format(BASE_EVENT_TYPE)
+        expected_str += '\nprogressEventType: TestEvent\n'
         mock_logger.info.assert_called_once_with(expected_str)
 
     @patch('ignition.service.progress_events.logger')
@@ -35,10 +35,10 @@ class TestProgressEventLogWriterService(unittest.TestCase):
         mock_log_type.lower.return_value = 'logstash'
         event = TestEvent(extra_details={'A': 123})
         self.service.add(event)
-        expected_str = 'eventType: {0}'.format(BASE_EVENT_TYPE)
-        expected_str += '\nprogressEventType: TestEvent'
-        expected_str += '\ndetails:'
-        expected_str += '\n  A: 123\n'
+        expected_str = 'details:\n'
+        expected_str += '  A: 123\n'
+        expected_str += 'eventType: {0}'.format(BASE_EVENT_TYPE)
+        expected_str += '\nprogressEventType: TestEvent\n'
         mock_logger.info.assert_called_once_with(expected_str)
 
     def test_add_invalid_event(self):


### PR DESCRIPTION
OrderedDict is not compatible with latest ansible, hence changing the OrderedDict to dict that maintain insertion order after python version 3.7.